### PR TITLE
Handle HttpPoison errors and return them instead of crashing

### DIFF
--- a/lib/ex_owm/api.ex
+++ b/lib/ex_owm/api.ex
@@ -36,4 +36,5 @@ defmodule ExOwm.Api do
 
   defp parse_json({:ok, json}), do: Jason.decode(json)
   defp parse_json({:error, reason, json_body}), do: {:error, reason, Jason.decode!(json_body)}
+  defp parse_json({:error, %HTTPoison.Error{} = reason}), do: {:error, reason}
 end


### PR DESCRIPTION
The get request will return `{:error, HTTPoison.Error.t()}` according to https://hexdocs.pm/httpoison/HTTPoison.html#get/3.

See an example error from our production here:
https://app.honeybadger.io/fault/103139/83f234d2ac885e901527b81dc604d17c

Not sure how to unit test this though.