### PR TITLE
Added handling for unknown api responses

### DIFF
--- a/lib/ex_owm/api.ex
+++ b/lib/ex_owm/api.ex
@@ -29,12 +29,16 @@ defmodule ExOwm.Api do
       {:ok, %HTTPoison.Response{status_code: 401, body: json_body}} ->
         {:error, :api_key_invalid, json_body}
 
-      error ->
-        error
+      {:ok, response} ->
+        {:error, :unknown_api_response, response}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
   defp parse_json({:ok, json}), do: Jason.decode(json)
+  defp parse_json({:error, :unknown_api_response, response}), do: {:error, :unknown_api_response, response}
   defp parse_json({:error, reason, json_body}), do: {:error, reason, Jason.decode!(json_body)}
   defp parse_json({:error, %HTTPoison.Error{} = reason}), do: {:error, reason}
 end


### PR DESCRIPTION
This was caused when the api call received a response which was unhandled, which caused the response to be Jason.decode'd.
This is a fix to handle unknown responses without raising a exception.